### PR TITLE
Add descriptive/tags prompt format toggle

### DIFF
--- a/prompt_enhancer_llm.py
+++ b/prompt_enhancer_llm.py
@@ -199,6 +199,7 @@ class PromptEnhancer:
                 "prompt": ("STRING", {"multiline": True, "default": "", "dynamicPrompts": False}),
                 "llm_provider": (providers, {"default": "openai"}),
                 "style": (all_styles, {"default": "Basic Styles > none"}),
+                "prompt_format": (["descriptive", "tags"], {"default": "descriptive"}),
             },
             "optional": {
                 "openai_key": ("STRING", {"multiline": False, "default": ""}),
@@ -223,7 +224,7 @@ class PromptEnhancer:
     def DISPLAY_NAME(cls):
         return "Prompt Enhancer LLM "
 
-    def enhance_prompt(self, clip, prompt, llm_provider, style, 
+    def enhance_prompt(self, clip, prompt, llm_provider, style, prompt_format="descriptive",
                       openai_key="", anthropic_key="", google_key="",
                       openrouter_key="", openrouter_model="google/gemma-2-9b-it:free",
                       ollama_host="http://localhost:11434", ollama_model="llama3.2:1b"):
@@ -238,6 +239,166 @@ class PromptEnhancer:
             # Skip if it's a category header
             if enhancement_style.startswith('[') and enhancement_style.endswith(']'):
                 enhancement_style = "detailed"  # Use default if category header is somehow selected
+
+            descriptive_system_prompt = (
+                "You are an expert at writing image generation prompts. Convert the input into a clear, descriptive prompt that directly describes the desired image. "
+                "Focus on nouns, adjectives, and visual elements. Do not reference specific characters, shows, movies or books unless asked to do so. "
+                "Do not include instructions like 'create', 'make', or 'generate'. Do not start the prompt with imagine or create. "
+                "Format the output as a simple description. Keep it to 5 sentences. Set descriptiveness to medium. "
+                "Plain text output only. No formatting. Only the prompt itself no additional text. Do not use quotations. Output to stable diffusion."
+            )
+
+            tag_system_prompt = 
+"""You are an expert prompt engineer for SDXL (Stable Diffusion XL) image generation.
+Your task is to transform a user's natural-language description of an image into a high-quality SDXL generation prompt consisting of descriptive tags and short tag-like phrases.
+## OUTPUT FORMAT
+Output ONLY the final SDXL prompt.
+Do not explain your choices.
+Do not use sentences, prose, bullet points, headings, markdown, or quotation marks.
+Do not prefix the output with anything such as "Prompt:".
+Separate tags and tag phrases with commas.
+The output should look like:
+masterpiece, best quality, 1girl, solo, long blonde hair, blue eyes, white dress, standing, looking at viewer, outdoors, forest, sunlight, detailed background
+## TAGGING PRINCIPLES
+Convert the user's description into concrete, visually recognizable tags.
+Prefer the vocabulary commonly used in Stable Diffusion / Danbooru-style image tagging and SDXL prompting where appropriate.
+Use specific visual concepts rather than abstract prose.
+Good:
+"long silver hair, red eyes, black gothic dress"
+Avoid:
+"she has beautiful silver hair that flows elegantly around her face"
+Good:
+"cinematic lighting, warm sunlight, rim lighting, shallow depth of field"
+Avoid:
+"the scene is beautifully illuminated by warm cinematic light"
+## INFORMATION PRIORITY
+Preserve important information from the user's description, prioritizing:
+1. Main subject
+2. Number of subjects
+3. Subject identity / type
+4. Age category when explicitly provided
+5. Gender presentation when explicitly provided
+6. Physical appearance
+7. Hair
+8. Eyes / facial features
+9. Clothing and accessories
+10. Pose and body position
+11. Facial expression
+12. Action
+13. Interaction between subjects
+14. Camera angle and viewpoint
+15. Composition
+16. Environment / setting
+17. Background
+18. Lighting
+19. Color palette
+20. Art style / medium
+21. Image quality / rendering characteristics
+Do not omit important details merely because they are difficult to express as tags.
+## SUBJECT TAGGING
+Clearly establish the primary subject near the beginning of the prompt.
+For human characters, use useful tags such as:
+1girl, 1boy, 2girls, solo, multiple girls, portrait, full body, upper body
+Follow with relevant physical characteristics:
+long hair, short hair, curly hair, blonde hair, black hair, blue eyes, pale skin, freckles, muscular, slender, etc.
+Do not invent physical characteristics that the user did not specify unless they are necessary to resolve an ambiguity.
+## CLOTHING
+Describe clothing using concise, recognizable tags.
+For example:
+white blouse, pleated skirt, thighhighs, leather jacket, red scarf, school uniform, gothic dress, armor, boots
+Include colors, materials, patterns, accessories, and distinctive garment details when provided.
+## POSE AND ACTION
+Translate descriptions of body position and actions into concise visual tags.
+Examples:
+standing, sitting, kneeling, lying down, walking, running, jumping, holding sword, holding flower, looking at viewer, looking away, arms crossed, hand on hip, raised arms
+For complex poses, use multiple complementary tags rather than prose.
+## COMPOSITION AND CAMERA
+When the description provides camera or composition information, express it explicitly.
+Useful tags include:
+close-up, portrait, bust, upper body, cowboy shot, full body, wide shot, extreme close-up
+high angle, low angle, bird's-eye view, worm's-eye view, side view, front view, rear view, three-quarter view
+centered composition, symmetrical composition, dynamic composition, rule of thirds
+depth of field, shallow depth of field, wide-angle lens, telephoto lens, perspective
+Do not add camera characteristics that conflict with the user's description.
+## ENVIRONMENT
+Translate locations into concrete visual tags.
+Examples:
+forest, city street, bedroom, castle interior, beach, mountain landscape, cyberpunk city, classroom, medieval village
+Add environmental details when specified:
+trees, flowers, skyscrapers, furniture, windows, clouds, mountains, water, candles, neon signs, etc.
+## LIGHTING
+Use concise lighting tags such as:
+soft lighting, dramatic lighting, cinematic lighting, rim lighting, backlighting, volumetric lighting, golden hour, moonlight, sunlight, warm lighting, cool lighting, ambient lighting
+Only add lighting characteristics when they fit the described scene.
+## STYLE
+Preserve explicitly requested artistic styles.
+Examples:
+anime, manga, realistic, photorealistic, semi-realistic, digital painting, oil painting, watercolor, concept art, fantasy art, cinematic, illustration
+If the user specifies a particular visual style, prioritize it.
+Do not automatically add a style that conflicts with the requested style.
+## QUALITY TAGS
+For illustrative or anime-oriented generations, quality tags may include:
+masterpiece, best quality, highly detailed, detailed background
+For photorealistic generations, prefer relevant photographic terminology instead of blindly adding anime-oriented quality tags.
+Do not overload the prompt with redundant quality tags.
+## WEIGHTS
+Use weighting syntax only when it is genuinely useful to emphasize an important concept.
+For example:
+(highly detailed face:1.2)
+Do not add weights everywhere.
+Do not use negative prompting syntax unless the user explicitly asks for a negative prompt.
+## PROMPT ORDER
+Generally organize the prompt in this order:
+quality/style, subject, subject characteristics, clothing, pose/action, composition/camera, environment, background, lighting, atmosphere, rendering details
+Keep the most important semantic information toward the beginning of the prompt.
+## INTERPRETATION
+Resolve natural-language descriptions into visual concepts.
+For example:
+"She looks nervous" -> nervous expression, anxious expression
+"Her hair is blowing in the wind" -> windblown hair
+"The room feels cozy" -> cozy interior, warm lighting, soft furnishings
+"He's staring intensely at the viewer" -> looking at viewer, intense gaze
+"An enormous dragon towers over the village" -> giant dragon, towering over village, village below, dramatic scale
+Do not mechanically copy the user's wording when a more useful visual tag exists.
+## DO NOT INVENT DETAILS
+Do not introduce specific objects, clothing, colors, poses, locations, characters, or artistic styles that are not supported by the user's description.
+You may infer minor visual details when they are strongly implied by the description, but never change the user's intended scene.
+If the user's description is ambiguous, choose the most visually natural interpretation without explaining it.
+## HANDLE COMPLEX DESCRIPTIONS
+When multiple subjects are present, make relationships and spatial positioning explicit.
+For example:
+2girls, standing together, girl in foreground, girl in background, looking at each other
+When the user specifies foreground/background relationships, preserve them.
+When the user specifies left/right positioning, preserve it:
+girl on left, boy on right
+When the user specifies interactions, preserve them:
+holding hands, hugging, sitting beside each other, looking at each other
+## TAG QUALITY
+Favor tags that are:
+* visually concrete
+* concise
+* recognizable by image-generation models
+* non-redundant
+* semantically specific
+* consistent with one another
+Avoid vague tags such as:
+nice, beautiful, awesome, interesting, amazing
+unless they correspond to a useful established visual concept.
+Avoid excessive synonym stacking such as:
+beautiful, gorgeous, stunning, pretty, attractive woman
+Prefer a single useful concept when possible.
+## USER INTENT
+The user's description is the source of truth.
+Do not critique the description.
+Do not ask questions unless absolutely necessary.
+Do not explain SDXL.
+Do not explain your tags.
+Do not provide alternative prompts.
+Do not provide negative prompts unless requested.
+Your sole output must be the optimized, comma-separated SDXL tag prompt."""
+
+            system_prompt = descriptive_system_prompt if prompt_format == "descriptive" else tag_system_prompt
+            user_prompt = f"{self.style_prompts[enhancement_style]} {prompt}"
             
             # Handle each provider
             if llm_provider == "openai":
@@ -247,8 +408,8 @@ class PromptEnhancer:
                 response = client.chat.completions.create(
                     model="gpt-4-turbo-preview",
                     messages=[
-                        {"role": "system", "content": "You are an expert at writing image generation prompts. Convert the input into a clear, descriptive prompt that directly describes the desired image. Focus on nouns, adjectives, and visual elements. Do not reference specific characters, shows, movies or books unless asked to do so. Do not include instructions like 'create', 'make', or 'generate'. Do not start the prompt with imagine or create.Format the output as a simple description. Keep it to 5 sentences. Set descriptiveness to medium. Plain text output only. No formatting. Only the prompt itself no additional text. Do not use quotations. Output to stable diffusion."},
-                        {"role": "user", "content": f"{self.style_prompts[enhancement_style]} {prompt}"}
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt}
                     ],
                     max_tokens=200,
                     temperature=0.7
@@ -263,7 +424,7 @@ class PromptEnhancer:
                     model="claude-3.5-sonnet",
                     max_tokens=200,
                     messages=[
-                        {"role": "user", "content": f"You are an expert at writing image generation prompts. Convert the input into a clear, descriptive prompt that directly describes the desired image. Focus on nouns, adjectives, and visual elements. Do not reference specific characters, shows, movies or books unless asked to do so. Do not include instructions like 'create', 'make', or 'generate'. Do not start the prompt with imagine or create.Format the output as a simple description. Keep it to 5 sentences. Set descriptiveness to medium. Plain text output only. No formatting. Only the prompt itself no additional text. Do not use quotations. Output to stable diffusion.\n\n{self.style_prompts[enhancement_style]} {prompt}"}
+                        {"role": "user", "content": f"{system_prompt}\n\n{user_prompt}"}
                     ]
                 )
                 enhanced_prompt = response.content[0].text.strip()
@@ -274,7 +435,7 @@ class PromptEnhancer:
                 genai_client.configure(api_key=google_key)
                 model = genai_client.GenerativeModel('gemini-pro')
                 response = model.generate_content(
-                    f"You are an expert at writing image generation prompts. Convert the input into a clear, descriptive prompt that directly describes the desired image. Focus on nouns, adjectives, and visual elements. Do not reference specific characters, shows, movies or books unless asked to do so. Do not include instructions like 'create', 'make', or 'generate'. Do not start the prompt with imagine or create.Format the output as a simple description. Keep it to 5 sentences. Set descriptiveness to medium. Plain text output only. No formatting. Only the prompt itself no additional text. Do not use quotations. Output to stable diffusion.\n\n{self.style_prompts[enhancement_style]} {prompt}"
+                    f"{system_prompt}\n\n{user_prompt}"
                 )
                 enhanced_prompt = response.text.strip()
                 
@@ -292,10 +453,7 @@ class PromptEnhancer:
                 success, message = self._test_ollama_connection(host, model_name)
                 if not success:
                     raise ValueError(f"Ollama connection failed: {message}")
-                
-                system_prompt = "You are an expert at writing image generation prompts. Convert the input into a clear, descriptive prompt that directly describes the desired image. Focus on nouns, adjectives, and visual elements. Do not include instructions like 'create', 'make', or 'generate'. Format the output as a simple description. Start with the focus object of the prompt. Use no more than 5 sentences. Set descriptiveness to medium. Plain text output only. No formatting. Only the prompt itself no additional text. Do not use quotations. Output to stable diffusion."
-                user_prompt = f"{self.style_prompts[enhancement_style]} {prompt}"
-                
+                                
                 url = f"{host}/api/generate"
                 payload = {
                     "model": model_name,
@@ -326,8 +484,8 @@ class PromptEnhancer:
                     response = self.clients[llm_provider].chat_completions(
                         model=openrouter_model,
                         messages=[
-                            {"role": "system", "content": "You are an expert at writing image generation prompts. Convert the input into a clear, descriptive prompt that directly describes the desired image. Focus on nouns, adjectives, and visual elements. Do not reference specific characters, shows, movies or books unless asked to do so. Do not include instructions like 'create', 'make', or 'generate'. Do not start the prompt with imagine or create.Format the output as a simple description. Keep it to 5 sentences. Set descriptiveness to medium. Plain text output only. No formatting. Only the prompt itself no additional text. Do not use quotations. Output to stable diffusion."},
-                            {"role": "user", "content": f"{self.style_prompts[enhancement_style]} {prompt}"}
+                            {"role": "system", "content": system_prompt},
+                            {"role": "user", "content": user_prompt}
                         ],
                         temperature=0.7
                     )


### PR DESCRIPTION
## Changes Made
- Added a new prompt_format dropdown with two options: descriptive and 	ags.
- descriptive uses the existing 5-sentence descriptive prompt behavior.
- 	ags uses the SDXL tag-style system prompt.
- Applied this prompt-format behavior consistently across all providers (OpenAI, Anthropic, Google, Ollama, OpenRouter).

## Note
- Existing workflows may need the Prompt Enhancer node to be deleted and re-added for the new dropdown input to appear correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing between descriptive prompt output and SDXL tag-based output.
  * SDXL tag output now provides comma-separated visual tags while preserving requested details.
  * Prompt formatting is applied consistently across all supported AI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->